### PR TITLE
fix: Fixed broken link in QuickStart guide.

### DIFF
--- a/spacebook/content/pages/quickstart.md
+++ b/spacebook/content/pages/quickstart.md
@@ -10,7 +10,7 @@ eleventyNavigation:
 These steps offer a great way to try out GLAuth in a non-production environment.  *Be warned that you should take the extra steps to setup SSL (TLS) for production use!*
 
 1. Download a precompiled binary from the [releases](https://github.com/glauth/glauth/releases) page.
-2. Download the [example config file](https://github.com/glauth/glauth/blob/master/sample-simple.cfg).
+2. Download the [example config file](https://github.com/glauth/glauth/blob/master/v2/sample-simple.cfg).
 3. Start the GLAuth server, referencing the path to the desired config file with `-c ./glauth64 -c sample-simple.cfg`
 4. Test with traditional LDAP tools
 


### PR DESCRIPTION
Fixes issue : https://github.com/glauth/glauth/issues/308

The link was broken/outdates so this PR fixes the issue.